### PR TITLE
Make the rules compatible with Apache 2.4 with mod_authz

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -225,22 +225,32 @@ SetEnvIfNoCase User-Agent "Baiduspider" bad_bot
 # Aggressive Russian Search Engine
 SetEnvIfNoCase User-Agent "Yandex" bad_bot
 
+# Cyveillance
+SetEnvIf Remote_Addr ^38\.100\.19\.[89]$ cyveillance                                        # 38.100.19.8/29
+SetEnvIf Remote_Addr ^38\.100\.21\.[0-9]+$ cyveillance                                      # 38.100.21.0/24
+SetEnvIf Remote_Addr ^38\.100\.41\.(6[4-9]|[789][0-9]|1([01][0-9]|2[0-7]))$ cyveillance     # 38.100.41.64/26
+SetEnvIf Remote_Addr ^38\.105\.71\.([0-9]|[1-9][0-9]|1([01][0-9]|2[0-7]))$ cyveillance      # 38.105.71.0/25
+SetEnvIf Remote_Addr ^38\.105\.83\.([0-9]|[12][0-9]|3[0-1])$ cyveillance                    # 38.105.83.0/27
+SetEnvIf Remote_Addr ^38\.112\.21\.14[0-3]$ cyveillance                                     # 38.112.21.140/30
+SetEnvIf Remote_Addr ^38\.118\.42\.3[2-9]$ cyveillance                                      # 38.118.42.32/29
+SetEnvIf Remote_Addr ^65\.213\.208\.1(2[89]|[345][0-9])$ cyveillance                        # 65.213.208.128/27
+SetEnvIf Remote_Addr ^65\.222\.176\.(9[6-9]|1([01][0-9]|2[0-7]))$ cyveillance               # 65.222.176.96/27
+SetEnvIf Remote_Addr ^65\.222\.185\.7[2-9]$ cyveillance                                     # 65.222.185.72/29
 
 <Limit GET POST HEAD>
-Order Allow,Deny
-Allow from all
-
-# Cyveillance
-deny from 38.100.19.8/29
-deny from 38.100.21.0/24
-deny from 38.100.41.64/26
-deny from 38.105.71.0/25
-deny from 38.105.83.0/27
-deny from 38.112.21.140/30
-deny from 38.118.42.32/29
-deny from 65.213.208.128/27
-deny from 65.222.176.96/27
-deny from 65.222.185.72/29
-
-Deny from env=bad_bot
+    <IfModule mod_authz_core.c>
+        <RequireAll>
+            Require all granted
+            <RequireNone>
+                Require env bad_bot
+                Require env cyveillance
+            </RequireNone>
+        </RequireAll>
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order Allow,Deny
+        Allow from all
+        Deny from env=bad_bot
+        Deny from env=cyveillance
+    </IfModule>
 </Limit>


### PR DESCRIPTION
Hi @bluedragons,

Your bad bot list is wonderful, but unfortunately the "deny from" syntax is not compatible Apache 2.4 with mod_authz. The old syntax is supported by mod_access_compat, but since that's just a compatibility layer, not all Apache 2.4 servers will have it installed by default.

I made some changes to make the rules work with mod_authz. Thanks to a trick found by the [Drupal folks](https://drupal.org/node/1599774) a while ago, it also works with earlier versions of Apache.

One problem is that SetEnvIf does not take CIDR ranges, so the Cyveillance ranges had to be translated into clunky regexps. This seems to work fine in my testing, but it's a bit ugly.

Thanks.

KS
